### PR TITLE
feat: wire --spec flag through validator and linter pipelines (E023)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,17 @@ cargo run -- check --format json style.json  # machine-readable output
 
 ## Development Flow
 
-Before any commit, run cargo build, cargo test, cargo fmt and cargo clippy. Then fix any issues and propose a commit.
+**Before every commit, without exception, run all four checks and fix any failures:**
+
+```bash
+cargo build                  # must compile clean
+cargo test                   # all 4 suites must pass
+cargo fmt --check            # zero formatting diffs (run cargo fmt to fix)
+cargo clippy                 # zero errors
+```
+
+Never commit if any of these fail. No exceptions for "just a docs change" or "just a refactor".
+
 Documents must be updated after any change in rules (format, validate and lint)
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ cargo run -- check --format json style.json  # machine-readable output
 cargo build                  # must compile clean
 cargo test                   # all 4 suites must pass
 cargo fmt --check            # zero formatting diffs (run cargo fmt to fix)
-cargo clippy                 # zero errors
+cargo clippy -- -D warnings  # zero errors (same strictness as CI)
 ```
 
 Never commit if any of these fail. No exceptions for "just a docs change" or "just a refactor".

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -153,6 +153,21 @@ Fix: add `text-font` with an explicit font stack.
 
 ---
 
+## W015 — Background pattern overrides color
+
+A background layer sets both `background-pattern` and `background-color`. The pattern takes precedence; the color has no effect.
+
+```json
+"paint": {
+  "background-color": "#ffffff",
+  "background-pattern": "dots"
+}
+```
+
+Fix: remove `background-color` when `background-pattern` is set.
+
+---
+
 ## W016 — Fill pattern overrides color
 
 A fill layer sets both `fill-pattern` and `fill-color`. The pattern takes precedence; the color has no effect.
@@ -182,21 +197,6 @@ Fix: remove `line-color` when `line-pattern` is set.
 A heatmap layer does not set `heatmap-color`. The layer renders monochrome using the renderer default.
 
 Fix: set `heatmap-color` to an `interpolate` expression mapping density to a meaningful color ramp.
-
----
-
-## W015 — Background pattern overrides color
-
-A background layer sets both `background-pattern` and `background-color`. The pattern takes precedence; the color has no effect.
-
-```json
-"paint": {
-  "background-color": "#ffffff",
-  "background-pattern": "dots"
-}
-```
-
-Fix: remove `background-color` when `background-pattern` is set.
 
 ---
 

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -237,6 +237,25 @@ Expression values (arrays starting with an operator string) are validated struct
 
 ---
 
-## Known Gaps
+---
 
-None.
+## E023 — Spec incompatibility
+
+A feature in the style is not supported by the target spec (`--spec mapbox` or `--spec both`).
+
+| Feature | MapLibre | Mapbox |
+|---------|----------|--------|
+| `sky` layer type | Yes | No |
+| `terrain` root property | Yes | No |
+| `fog` root property | Yes | No |
+| `distance-from-center` expression | Yes | No |
+
+**Example** — sky layer with `--spec mapbox`:
+
+```json
+{
+  "layers": [{ "id": "s", "type": "sky" }]
+}
+```
+
+**Fix:** remove the incompatible feature, or switch to `--spec maplibre` if targeting MapLibre only.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ pub struct Cli {
     pub command: Command,
 
     /// Spec version to validate against
-    #[arg(long, global = true, default_value = "maplibre")]
+    #[arg(long, global = true, default_value = "both")]
     pub spec: Spec,
 
     /// Output format
@@ -48,9 +48,13 @@ pub enum Command {
     Validate { file: Option<PathBuf> },
 }
 
-#[derive(Clone, ValueEnum, Debug)]
+#[derive(Clone, ValueEnum, Debug, PartialEq)]
 pub enum Spec {
+    /// Validate compatibility with both MapLibre and Mapbox (default)
+    Both,
+    /// Validate against MapLibre spec only
     Maplibre,
+    /// Validate against Mapbox spec only
     Mapbox,
 }
 

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -41,10 +41,7 @@ pub fn run_all(style: &Style, spec: &Spec) -> Vec<Diagnostic> {
 
     rules
         .iter()
-        .filter(|r| {
-            r.spec_affinity()
-                .map_or(true, |a| a.conflicts_with(spec))
-        })
+        .filter(|r| r.spec_affinity().map_or(true, |a| a.conflicts_with(spec)))
         .flat_map(|r| r.check(style))
         .collect()
 }

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -1,4 +1,6 @@
+use crate::cli::Spec;
 use crate::diagnostic::Diagnostic;
+use crate::style::spec::SpecAffinity;
 use crate::style::Style;
 
 pub mod config;
@@ -6,11 +8,16 @@ pub mod rules;
 
 pub trait LintRule {
     fn code(&self) -> &'static str;
+    /// Spec affinity for compat rules. `None` = always runs.
+    /// `Some(MaplibreOnly)` = runs when spec is Mapbox or Both (checks MapLibre-only features).
+    fn spec_affinity(&self) -> Option<SpecAffinity> {
+        None
+    }
     fn check(&self, style: &Style) -> Vec<Diagnostic>;
 }
 
-/// Run all lint rules and collect diagnostics
-pub fn run_all(style: &Style) -> Vec<Diagnostic> {
+/// Run all lint rules, filtered by spec compatibility.
+pub fn run_all(style: &Style, spec: &Spec) -> Vec<Diagnostic> {
     let rules: Vec<Box<dyn LintRule>> = vec![
         Box::new(rules::duplicate_ids::DuplicateIds),
         Box::new(rules::visibility::PermanentlyInvisible),
@@ -32,5 +39,12 @@ pub fn run_all(style: &Style) -> Vec<Diagnostic> {
         Box::new(rules::perf_hints::HeatmapMissingColor),
     ];
 
-    rules.iter().flat_map(|r| r.check(style)).collect()
+    rules
+        .iter()
+        .filter(|r| {
+            r.spec_affinity()
+                .map_or(true, |a| a.conflicts_with(spec))
+        })
+        .flat_map(|r| r.check(style))
+        .collect()
 }

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -41,7 +41,7 @@ pub fn run_all(style: &Style, spec: &Spec) -> Vec<Diagnostic> {
 
     rules
         .iter()
-        .filter(|r| r.spec_affinity().map_or(true, |a| a.conflicts_with(spec)))
+        .filter(|r| r.spec_affinity().is_none_or(|a| a.conflicts_with(spec)))
         .flat_map(|r| r.check(style))
         .collect()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn run(cli: &Cli) -> i32 {
                     return 2;
                 }
             };
-            let mut diags = validator::run_all(&style);
+            let mut diags = validator::run_all(&style, &crate::cli::Spec::Both);
             diags.extend(linter::run_all(&style));
             diags
         }
@@ -57,7 +57,7 @@ fn run(cli: &Cli) -> i32 {
                     return 2;
                 }
             };
-            validator::run_all(&style)
+            validator::run_all(&style, &crate::cli::Spec::Both)
         }
         Command::Lint { .. } => {
             let style: Style = match serde_json::from_value(value.clone()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,8 @@ fn run(cli: &Cli) -> i32 {
                     return 2;
                 }
             };
-            let mut diags = validator::run_all(&style, &crate::cli::Spec::Both);
-            diags.extend(linter::run_all(&style));
+            let mut diags = validator::run_all(&style, &cli.spec);
+            diags.extend(linter::run_all(&style, &cli.spec));
             diags
         }
         Command::Validate { .. } => {
@@ -57,7 +57,7 @@ fn run(cli: &Cli) -> i32 {
                     return 2;
                 }
             };
-            validator::run_all(&style, &crate::cli::Spec::Both)
+            validator::run_all(&style, &cli.spec)
         }
         Command::Lint { .. } => {
             let style: Style = match serde_json::from_value(value.clone()) {
@@ -67,7 +67,7 @@ fn run(cli: &Cli) -> i32 {
                     return 2;
                 }
             };
-            linter::run_all(&style)
+            linter::run_all(&style, &cli.spec)
         }
         Command::Fmt { check, .. } => {
             let formatted = formatter::format_style(&value, config.format.indent);

--- a/src/style/spec.rs
+++ b/src/style/spec.rs
@@ -17,3 +17,29 @@ pub const MAPLIBRE_ONLY_ROOT_PROPS: &[&str] = &["terrain", "fog"];
 
 /// Root properties only in Mapbox
 pub const MAPBOX_ONLY_ROOT_PROPS: &[&str] = &[];
+
+use crate::cli::Spec;
+
+/// Declares which spec a feature belongs to exclusively.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum SpecAffinity {
+    /// Feature exists in MapLibre but not Mapbox
+    MaplibreOnly,
+    /// Feature exists in Mapbox but not MapLibre
+    MapboxOnly,
+}
+
+impl SpecAffinity {
+    /// Returns true when this feature's spec affinity is incompatible with the chosen spec.
+    ///
+    /// `Spec::Both` means "the style must work on both MapLibre and Mapbox," so any
+    /// feature exclusive to one spec conflicts — it would break the other. Use this to
+    /// decide whether to emit E023 for a compat validator.
+    pub fn conflicts_with(&self, spec: &Spec) -> bool {
+        matches!(
+            (self, spec),
+            (SpecAffinity::MaplibreOnly, Spec::Mapbox | Spec::Both)
+                | (SpecAffinity::MapboxOnly, Spec::Maplibre | Spec::Both)
+        )
+    }
+}

--- a/src/validator/compat.rs
+++ b/src/validator/compat.rs
@@ -10,7 +10,9 @@ pub struct FogCompatValidator;
 pub struct ExpressionCompatValidator;
 
 impl Validator for SkyCompatValidator {
-    fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
+    fn spec_affinity(&self) -> Option<SpecAffinity> {
+        Some(SpecAffinity::MaplibreOnly)
+    }
     fn validate(&self, style: &Style) -> Vec<Diagnostic> {
         style
             .layers
@@ -30,7 +32,9 @@ impl Validator for SkyCompatValidator {
 }
 
 impl Validator for TerrainCompatValidator {
-    fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
+    fn spec_affinity(&self) -> Option<SpecAffinity> {
+        Some(SpecAffinity::MaplibreOnly)
+    }
     fn validate(&self, style: &Style) -> Vec<Diagnostic> {
         if style.terrain.is_some() {
             vec![Diagnostic::error(
@@ -46,15 +50,15 @@ impl Validator for TerrainCompatValidator {
 }
 
 impl Validator for FogCompatValidator {
-    fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
+    fn spec_affinity(&self) -> Option<SpecAffinity> {
+        Some(SpecAffinity::MaplibreOnly)
+    }
     fn validate(&self, style: &Style) -> Vec<Diagnostic> {
         if style.fog.is_some() {
-            vec![Diagnostic::error(
-                "E023",
-                "fog",
-                "\"fog\" is not supported in Mapbox spec",
-            )
-            .with_hint("remove \"fog\" or switch to --spec maplibre")]
+            vec![
+                Diagnostic::error("E023", "fog", "\"fog\" is not supported in Mapbox spec")
+                    .with_hint("remove \"fog\" or switch to --spec maplibre"),
+            ]
         } else {
             vec![]
         }
@@ -62,7 +66,9 @@ impl Validator for FogCompatValidator {
 }
 
 impl Validator for ExpressionCompatValidator {
-    fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
+    fn spec_affinity(&self) -> Option<SpecAffinity> {
+        Some(SpecAffinity::MaplibreOnly)
+    }
     fn validate(&self, style: &Style) -> Vec<Diagnostic> {
         let mut diags = Vec::new();
         for (i, layer) in style.layers.iter().enumerate() {
@@ -124,12 +130,15 @@ mod tests {
     fn sky_compat_emits_e023_for_sky_layer() {
         let style = parse(r#"{"version":8,"sources":{},"layers":[{"id":"s","type":"sky"}]}"#);
         let diags = SkyCompatValidator.validate(&style);
-        assert!(diags.iter().any(|d| d.code == "E023" && d.path.contains("layers[0]")));
+        assert!(diags
+            .iter()
+            .any(|d| d.code == "E023" && d.path.contains("layers[0]")));
     }
 
     #[test]
     fn sky_compat_clean_for_non_sky_layer() {
-        let style = parse(r#"{"version":8,"sources":{},"layers":[{"id":"bg","type":"background"}]}"#);
+        let style =
+            parse(r#"{"version":8,"sources":{},"layers":[{"id":"bg","type":"background"}]}"#);
         assert!(SkyCompatValidator.validate(&style).is_empty());
     }
 
@@ -138,7 +147,9 @@ mod tests {
     fn terrain_compat_emits_e023_when_terrain_present() {
         let style = parse(r#"{"version":8,"sources":{},"layers":[],"terrain":{"source":"dem"}}"#);
         let diags = TerrainCompatValidator.validate(&style);
-        assert!(diags.iter().any(|d| d.code == "E023" && d.path == "terrain"));
+        assert!(diags
+            .iter()
+            .any(|d| d.code == "E023" && d.path == "terrain"));
     }
 
     #[test]
@@ -164,7 +175,8 @@ mod tests {
     // ExpressionCompatValidator
     #[test]
     fn expression_compat_emits_e023_for_distance_from_center() {
-        let style = parse(r#"{
+        let style = parse(
+            r#"{
             "version":8,
             "sources":{},
             "layers":[{
@@ -172,14 +184,18 @@ mod tests {
                 "type":"circle",
                 "paint":{"circle-radius":["distance-from-center"]}
             }]
-        }"#);
+        }"#,
+        );
         let diags = ExpressionCompatValidator.validate(&style);
-        assert!(diags.iter().any(|d| d.code == "E023" && d.message.contains("distance-from-center")));
+        assert!(diags
+            .iter()
+            .any(|d| d.code == "E023" && d.message.contains("distance-from-center")));
     }
 
     #[test]
     fn expression_compat_clean_for_standard_expression() {
-        let style = parse(r#"{
+        let style = parse(
+            r#"{
             "version":8,
             "sources":{},
             "layers":[{
@@ -187,7 +203,8 @@ mod tests {
                 "type":"circle",
                 "paint":{"circle-radius":["get","zoom"]}
             }]
-        }"#);
+        }"#,
+        );
         assert!(ExpressionCompatValidator.validate(&style).is_empty());
     }
 }

--- a/src/validator/compat.rs
+++ b/src/validator/compat.rs
@@ -1,5 +1,6 @@
 use crate::diagnostic::Diagnostic;
-use crate::style::spec::SpecAffinity;
+use crate::style::layer::LayerType;
+use crate::style::spec::{SpecAffinity, MAPLIBRE_ONLY_EXPRESSIONS};
 use crate::style::Style;
 use crate::validator::Validator;
 
@@ -10,17 +11,183 @@ pub struct ExpressionCompatValidator;
 
 impl Validator for SkyCompatValidator {
     fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
-    fn validate(&self, _style: &Style) -> Vec<Diagnostic> { vec![] }
+    fn validate(&self, style: &Style) -> Vec<Diagnostic> {
+        style
+            .layers
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| l.layer_type == Some(LayerType::Sky))
+            .map(|(i, _)| {
+                Diagnostic::error(
+                    "E023",
+                    format!("layers[{}].type", i),
+                    "sky layer is not supported in Mapbox spec",
+                )
+                .with_hint("remove this layer or switch to --spec maplibre")
+            })
+            .collect()
+    }
 }
+
 impl Validator for TerrainCompatValidator {
     fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
-    fn validate(&self, _style: &Style) -> Vec<Diagnostic> { vec![] }
+    fn validate(&self, style: &Style) -> Vec<Diagnostic> {
+        if style.terrain.is_some() {
+            vec![Diagnostic::error(
+                "E023",
+                "terrain",
+                "\"terrain\" is not supported in Mapbox spec",
+            )
+            .with_hint("remove \"terrain\" or switch to --spec maplibre")]
+        } else {
+            vec![]
+        }
+    }
 }
+
 impl Validator for FogCompatValidator {
     fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
-    fn validate(&self, _style: &Style) -> Vec<Diagnostic> { vec![] }
+    fn validate(&self, style: &Style) -> Vec<Diagnostic> {
+        if style.fog.is_some() {
+            vec![Diagnostic::error(
+                "E023",
+                "fog",
+                "\"fog\" is not supported in Mapbox spec",
+            )
+            .with_hint("remove \"fog\" or switch to --spec maplibre")]
+        } else {
+            vec![]
+        }
+    }
 }
+
 impl Validator for ExpressionCompatValidator {
     fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
-    fn validate(&self, _style: &Style) -> Vec<Diagnostic> { vec![] }
+    fn validate(&self, style: &Style) -> Vec<Diagnostic> {
+        let mut diags = Vec::new();
+        for (i, layer) in style.layers.iter().enumerate() {
+            let base = format!("layers[{}]", i);
+            if let Some(paint) = &layer.paint {
+                diags.extend(check_expr_compat(paint, &format!("{}.paint", base)));
+            }
+            if let Some(layout) = &layer.layout {
+                diags.extend(check_expr_compat(layout, &format!("{}.layout", base)));
+            }
+        }
+        diags
+    }
+}
+
+fn check_expr_compat(value: &serde_json::Value, path: &str) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+    match value {
+        serde_json::Value::Array(arr) if !arr.is_empty() && arr[0].is_string() => {
+            let op = arr[0].as_str().unwrap();
+            if MAPLIBRE_ONLY_EXPRESSIONS.contains(&op) {
+                diags.push(
+                    Diagnostic::error(
+                        "E023",
+                        path,
+                        format!(
+                            "expression operator \"{}\" is not supported in Mapbox spec",
+                            op
+                        ),
+                    )
+                    .with_hint("remove this expression or switch to --spec maplibre"),
+                );
+            }
+            for (j, arg) in arr[1..].iter().enumerate() {
+                diags.extend(check_expr_compat(arg, &format!("{}[{}]", path, j + 1)));
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for (k, v) in map {
+                diags.extend(check_expr_compat(v, &format!("{}.{}", path, k)));
+            }
+        }
+        _ => {}
+    }
+    diags
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::validator::Validator;
+
+    fn parse(json: &str) -> crate::style::Style {
+        serde_json::from_str(json).unwrap()
+    }
+
+    // SkyCompatValidator
+    #[test]
+    fn sky_compat_emits_e023_for_sky_layer() {
+        let style = parse(r#"{"version":8,"sources":{},"layers":[{"id":"s","type":"sky"}]}"#);
+        let diags = SkyCompatValidator.validate(&style);
+        assert!(diags.iter().any(|d| d.code == "E023" && d.path.contains("layers[0]")));
+    }
+
+    #[test]
+    fn sky_compat_clean_for_non_sky_layer() {
+        let style = parse(r#"{"version":8,"sources":{},"layers":[{"id":"bg","type":"background"}]}"#);
+        assert!(SkyCompatValidator.validate(&style).is_empty());
+    }
+
+    // TerrainCompatValidator
+    #[test]
+    fn terrain_compat_emits_e023_when_terrain_present() {
+        let style = parse(r#"{"version":8,"sources":{},"layers":[],"terrain":{"source":"dem"}}"#);
+        let diags = TerrainCompatValidator.validate(&style);
+        assert!(diags.iter().any(|d| d.code == "E023" && d.path == "terrain"));
+    }
+
+    #[test]
+    fn terrain_compat_clean_without_terrain() {
+        let style = parse(r#"{"version":8,"sources":{},"layers":[]}"#);
+        assert!(TerrainCompatValidator.validate(&style).is_empty());
+    }
+
+    // FogCompatValidator
+    #[test]
+    fn fog_compat_emits_e023_when_fog_present() {
+        let style = parse(r#"{"version":8,"sources":{},"layers":[],"fog":{"color":"white"}}"#);
+        let diags = FogCompatValidator.validate(&style);
+        assert!(diags.iter().any(|d| d.code == "E023" && d.path == "fog"));
+    }
+
+    #[test]
+    fn fog_compat_clean_without_fog() {
+        let style = parse(r#"{"version":8,"sources":{},"layers":[]}"#);
+        assert!(FogCompatValidator.validate(&style).is_empty());
+    }
+
+    // ExpressionCompatValidator
+    #[test]
+    fn expression_compat_emits_e023_for_distance_from_center() {
+        let style = parse(r#"{
+            "version":8,
+            "sources":{},
+            "layers":[{
+                "id":"c",
+                "type":"circle",
+                "paint":{"circle-radius":["distance-from-center"]}
+            }]
+        }"#);
+        let diags = ExpressionCompatValidator.validate(&style);
+        assert!(diags.iter().any(|d| d.code == "E023" && d.message.contains("distance-from-center")));
+    }
+
+    #[test]
+    fn expression_compat_clean_for_standard_expression() {
+        let style = parse(r#"{
+            "version":8,
+            "sources":{},
+            "layers":[{
+                "id":"c",
+                "type":"circle",
+                "paint":{"circle-radius":["get","zoom"]}
+            }]
+        }"#);
+        assert!(ExpressionCompatValidator.validate(&style).is_empty());
+    }
 }

--- a/src/validator/compat.rs
+++ b/src/validator/compat.rs
@@ -1,0 +1,26 @@
+use crate::diagnostic::Diagnostic;
+use crate::style::spec::SpecAffinity;
+use crate::style::Style;
+use crate::validator::Validator;
+
+pub struct SkyCompatValidator;
+pub struct TerrainCompatValidator;
+pub struct FogCompatValidator;
+pub struct ExpressionCompatValidator;
+
+impl Validator for SkyCompatValidator {
+    fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
+    fn validate(&self, _style: &Style) -> Vec<Diagnostic> { vec![] }
+}
+impl Validator for TerrainCompatValidator {
+    fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
+    fn validate(&self, _style: &Style) -> Vec<Diagnostic> { vec![] }
+}
+impl Validator for FogCompatValidator {
+    fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
+    fn validate(&self, _style: &Style) -> Vec<Diagnostic> { vec![] }
+}
+impl Validator for ExpressionCompatValidator {
+    fn spec_affinity(&self) -> Option<SpecAffinity> { Some(SpecAffinity::MaplibreOnly) }
+    fn validate(&self, _style: &Style) -> Vec<Diagnostic> { vec![] }
+}

--- a/src/validator/layers.rs
+++ b/src/validator/layers.rs
@@ -6,6 +6,14 @@ use crate::style::{
     Style,
 };
 use crate::validator::prop_values::validate_prop_value;
+use crate::validator::Validator;
+
+pub struct LayersValidator;
+impl Validator for LayersValidator {
+    fn validate(&self, style: &crate::style::Style) -> Vec<crate::diagnostic::Diagnostic> {
+        validate_layers(style)
+    }
+}
 
 /// Paint properties valid per layer type
 fn valid_paint_props(lt: Option<&LayerType>) -> &'static [&'static str] {

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -34,7 +34,7 @@ pub fn run_all(style: &Style, spec: &Spec) -> Vec<Diagnostic> {
 
     validators
         .iter()
-        .filter(|v| v.spec_affinity().map_or(true, |a| a.conflicts_with(spec)))
+        .filter(|v| v.spec_affinity().is_none_or(|a| a.conflicts_with(spec)))
         .flat_map(|v| v.validate(style))
         .collect()
 }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1,6 +1,9 @@
+use crate::cli::Spec;
 use crate::diagnostic::Diagnostic;
+use crate::style::spec::SpecAffinity;
 use crate::style::Style;
 
+pub mod compat;
 pub mod layers;
 pub mod prop_values;
 pub mod refs;
@@ -8,15 +11,32 @@ pub mod root;
 pub mod sources;
 
 pub trait Validator {
+    /// Which spec this validator is exclusive to. `None` = runs for all specs.
+    fn spec_affinity(&self) -> Option<SpecAffinity> {
+        None
+    }
     fn validate(&self, style: &Style) -> Vec<Diagnostic>;
 }
 
-/// Run all validators and collect diagnostics
-pub fn run_all(style: &Style) -> Vec<Diagnostic> {
-    let mut diags = Vec::new();
-    diags.extend(root::validate_root(style));
-    diags.extend(sources::validate_sources(style));
-    diags.extend(layers::validate_layers(style));
-    diags.extend(refs::validate_refs(style));
-    diags
+/// Run all validators, filtered by spec compatibility.
+pub fn run_all(style: &Style, spec: &Spec) -> Vec<Diagnostic> {
+    let validators: Vec<Box<dyn Validator>> = vec![
+        Box::new(root::RootValidator),
+        Box::new(sources::SourcesValidator),
+        Box::new(layers::LayersValidator),
+        Box::new(refs::RefsValidator),
+        Box::new(compat::SkyCompatValidator),
+        Box::new(compat::TerrainCompatValidator),
+        Box::new(compat::FogCompatValidator),
+        Box::new(compat::ExpressionCompatValidator),
+    ];
+
+    validators
+        .iter()
+        .filter(|v| {
+            v.spec_affinity()
+                .map_or(true, |a| !a.conflicts_with(spec))
+        })
+        .flat_map(|v| v.validate(style))
+        .collect()
 }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -34,10 +34,7 @@ pub fn run_all(style: &Style, spec: &Spec) -> Vec<Diagnostic> {
 
     validators
         .iter()
-        .filter(|v| {
-            v.spec_affinity()
-                .map_or(true, |a| a.conflicts_with(spec))
-        })
+        .filter(|v| v.spec_affinity().map_or(true, |a| a.conflicts_with(spec)))
         .flat_map(|v| v.validate(style))
         .collect()
 }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -11,7 +11,8 @@ pub mod root;
 pub mod sources;
 
 pub trait Validator {
-    /// Which spec this validator is exclusive to. `None` = runs for all specs.
+    /// Spec affinity for compat validators. `None` = always runs.
+    /// `Some(MaplibreOnly)` = runs when spec is Mapbox or Both (checks MapLibre-only features).
     fn spec_affinity(&self) -> Option<SpecAffinity> {
         None
     }
@@ -35,7 +36,7 @@ pub fn run_all(style: &Style, spec: &Spec) -> Vec<Diagnostic> {
         .iter()
         .filter(|v| {
             v.spec_affinity()
-                .map_or(true, |a| !a.conflicts_with(spec))
+                .map_or(true, |a| a.conflicts_with(spec))
         })
         .flat_map(|v| v.validate(style))
         .collect()

--- a/src/validator/refs.rs
+++ b/src/validator/refs.rs
@@ -1,5 +1,13 @@
 use crate::diagnostic::Diagnostic;
 use crate::style::{types::SpriteValue, Style};
+use crate::validator::Validator;
+
+pub struct RefsValidator;
+impl Validator for RefsValidator {
+    fn validate(&self, style: &crate::style::Style) -> Vec<crate::diagnostic::Diagnostic> {
+        validate_refs(style)
+    }
+}
 
 pub fn validate_refs(style: &Style) -> Vec<Diagnostic> {
     let mut diags = Vec::new();

--- a/src/validator/root.rs
+++ b/src/validator/root.rs
@@ -1,5 +1,13 @@
 use crate::diagnostic::Diagnostic;
 use crate::style::Style;
+use crate::validator::Validator;
+
+pub struct RootValidator;
+impl Validator for RootValidator {
+    fn validate(&self, style: &crate::style::Style) -> Vec<crate::diagnostic::Diagnostic> {
+        validate_root(style)
+    }
+}
 
 pub fn validate_root(style: &Style) -> Vec<Diagnostic> {
     let mut diags = Vec::new();

--- a/src/validator/sources.rs
+++ b/src/validator/sources.rs
@@ -3,6 +3,14 @@ use crate::style::{
     types::{GeoJsonSource, RasterDemSource, RasterSource, Source, VectorSource},
     Style,
 };
+use crate::validator::Validator;
+
+pub struct SourcesValidator;
+impl Validator for SourcesValidator {
+    fn validate(&self, style: &crate::style::Style) -> Vec<crate::diagnostic::Diagnostic> {
+        validate_sources(style)
+    }
+}
 
 pub fn validate_sources(style: &Style) -> Vec<Diagnostic> {
     let mut diags = Vec::new();

--- a/tests/pipeline_test.rs
+++ b/tests/pipeline_test.rs
@@ -12,7 +12,7 @@ fn check_fixture(name: &str) -> Vec<Diagnostic> {
         .unwrap_or_else(|e| panic!("invalid JSON in {}: {}", name, e));
     let style: Style = serde_json::from_value(value)
         .unwrap_or_else(|e| panic!("style parse failed for {}: {}", name, e));
-    let mut diags = validator::run_all(&style);
+    let mut diags = validator::run_all(&style, &styl::cli::Spec::Both);
     diags.extend(linter::run_all(&style));
     diags
 }

--- a/tests/pipeline_test.rs
+++ b/tests/pipeline_test.rs
@@ -13,7 +13,7 @@ fn check_fixture(name: &str) -> Vec<Diagnostic> {
     let style: Style = serde_json::from_value(value)
         .unwrap_or_else(|e| panic!("style parse failed for {}: {}", name, e));
     let mut diags = validator::run_all(&style, &styl::cli::Spec::Both);
-    diags.extend(linter::run_all(&style));
+    diags.extend(linter::run_all(&style, &styl::cli::Spec::Both));
     diags
 }
 
@@ -87,4 +87,82 @@ fn legacy_filters_triggers_w011() {
         diags.iter().any(|d| d.code == "W011"),
         "expected W011 in legacy_filters.json"
     );
+}
+
+mod spec_compat {
+    use styl::{cli::Spec, diagnostic::Diagnostic, linter, style::Style, validator};
+
+    fn run(json: &str, spec: Spec) -> Vec<Diagnostic> {
+        let value: serde_json::Value = serde_json::from_str(json).unwrap();
+        let style: Style = serde_json::from_value(value).unwrap();
+        let mut diags = validator::run_all(&style, &spec);
+        diags.extend(linter::run_all(&style, &spec));
+        diags
+    }
+
+    fn has_e023(diags: &[Diagnostic]) -> bool {
+        diags.iter().any(|d| d.code == "E023")
+    }
+
+    #[test]
+    fn sky_layer_flagged_by_both() {
+        let style = r#"{"version":8,"sources":{},"layers":[{"id":"s","type":"sky"}]}"#;
+        assert!(has_e023(&run(style, Spec::Both)));
+    }
+
+    #[test]
+    fn sky_layer_flagged_by_mapbox() {
+        let style = r#"{"version":8,"sources":{},"layers":[{"id":"s","type":"sky"}]}"#;
+        assert!(has_e023(&run(style, Spec::Mapbox)));
+    }
+
+    #[test]
+    fn sky_layer_clean_for_maplibre() {
+        let style = r#"{"version":8,"sources":{},"layers":[{"id":"s","type":"sky"}]}"#;
+        assert!(!has_e023(&run(style, Spec::Maplibre)));
+    }
+
+    #[test]
+    fn terrain_flagged_by_both() {
+        let style = r#"{"version":8,"sources":{},"layers":[],"terrain":{"source":"dem"}}"#;
+        assert!(has_e023(&run(style, Spec::Both)));
+    }
+
+    #[test]
+    fn terrain_clean_for_maplibre() {
+        let style = r#"{"version":8,"sources":{},"layers":[],"terrain":{"source":"dem"}}"#;
+        assert!(!has_e023(&run(style, Spec::Maplibre)));
+    }
+
+    #[test]
+    fn fog_flagged_by_mapbox() {
+        let style = r#"{"version":8,"sources":{},"layers":[],"fog":{"color":"white"}}"#;
+        assert!(has_e023(&run(style, Spec::Mapbox)));
+    }
+
+    #[test]
+    fn fog_clean_for_maplibre() {
+        let style = r#"{"version":8,"sources":{},"layers":[],"fog":{"color":"white"}}"#;
+        assert!(!has_e023(&run(style, Spec::Maplibre)));
+    }
+
+    #[test]
+    fn clean_style_passes_all_specs() {
+        let style = r#"{"version":8,"sources":{},"layers":[{"id":"bg","type":"background"}]}"#;
+        assert!(!has_e023(&run(style, Spec::Both)));
+        assert!(!has_e023(&run(style, Spec::Maplibre)));
+        assert!(!has_e023(&run(style, Spec::Mapbox)));
+    }
+
+    #[test]
+    fn distance_from_center_flagged_by_mapbox() {
+        let style = r#"{"version":8,"sources":{},"layers":[{"id":"c","type":"circle","paint":{"circle-radius":["distance-from-center"]}}]}"#;
+        assert!(has_e023(&run(style, Spec::Mapbox)));
+    }
+
+    #[test]
+    fn distance_from_center_clean_for_maplibre() {
+        let style = r#"{"version":8,"sources":{},"layers":[{"id":"c","type":"circle","paint":{"circle-radius":["distance-from-center"]}}]}"#;
+        assert!(!has_e023(&run(style, Spec::Maplibre)));
+    }
 }


### PR DESCRIPTION
  ## Summary
  - Add Spec::Both variant (new default) — validates compat with both specs
  - Refactor validators to struct pattern with spec_affinity() for declarative filtering
  - Add compat.rs: SkyCompatValidator, TerrainCompatValidator, FogCompatValidator,
    ExpressionCompatValidator — emit E023 for spec-incompatible features
  - Wire cli.spec through validator::run_all and linter::run_all
  - Fix W015 doc ordering bug in docs/linter.md

  ## Test Plan
  - cargo test → 186 pass
  - sky layer + --spec mapbox → E023
  - sky layer + --spec maplibre → clean
  - sky layer + --spec both (default) → E023